### PR TITLE
完成資料前 N 多的公司，不同職業的平均薪資

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -5,10 +5,10 @@ type Archive {
 
 """單一公司單一職稱的平均薪資"""
 type AverageSalary {
-  job_title: JobTitle!
   company: Company!
-  data_num: Int!
-  average_salary: Salary!
+  job_title: JobTitle!
+  data_count: Int!
+  salary: Salary!
 }
 
 type Company {
@@ -25,12 +25,6 @@ type Company {
   interview_experience_statistics: InterviewExperienceStatistics!
 
   """該公司內不同職業的平均薪資"""
-  job_title_average_salaries: [AverageSalary!]
-}
-
-"""單一公司內不同職稱的平均薪資資料"""
-type companyAverageSalary {
-  company: Company!
   average_salaries: [AverageSalary!]
 }
 
@@ -173,13 +167,7 @@ type JobTitle {
   interview_experience_statistics: InterviewExperienceStatistics!
 
   """該職業的薪資分布"""
-  salary_distribution: JobTitleSalaryDistribution!
-}
-
-"""單一職稱的薪資分布"""
-type JobTitleSalaryDistribution {
-  job_title: JobTitle!
-  bins: [SalaryDistributionBin!]
+  salary_distribution: SalaryDistribution!
 }
 
 type LaborRight {
@@ -213,6 +201,12 @@ enum Order {
   ASCENDING
 }
 
+"""加班頻率的次數"""
+type OvertimeFrequencyCount {
+  overtime_frequency: Int!
+  count: Int!
+}
+
 """發布狀態"""
 enum PublishStatus {
   published
@@ -227,6 +221,9 @@ type Query {
   search_companies(query: String!): [Company!]!
   company(name: String!): Company
 
+  """目前用途：取得薪資資料前 topN 多的公司，且至少有三種職稱各至少有三筆資料"""
+  popular_companies(limit: Int = 5): [Company!]!
+
   """取得單篇經驗分享"""
   experience(id: ID!): Experience
   popular_experiences(
@@ -237,6 +234,9 @@ type Query {
   job_title_keywords(limit: Int = 5): [String!]!
   search_job_titles(query: String!): [JobTitle!]!
   job_title(name: String!): JobTitle
+
+  """目前用途：取得薪資資料前 topN 多的職稱"""
+  popular_job_titles(limit: Int = 5): [JobTitle!]!
   labor_rights: [LaborRight!]!
   labor_right(id: ID!): LaborRight
   me: User!
@@ -246,12 +246,6 @@ type Query {
 
   """薪資工時總數"""
   salary_work_time_count: Int!
-
-  """取得資料數較多的公司，不同職業的平均薪資"""
-  popular_company_average_salary: [companyAverageSalary]
-
-  """取得資料數較多的職稱的薪資分佈"""
-  popular_job_title_salary_distribution: [JobTitleSalaryDistribution]
 }
 
 type Reply {
@@ -275,9 +269,14 @@ type Salary {
   amount: Int
 }
 
+"""薪資分布"""
+type SalaryDistribution {
+  bins: [SalaryDistributionBin!]
+}
+
 """薪資分布的一個 bin（範圍＋數量）"""
 type SalaryDistributionBin {
-  data_num: Int!
+  data_count: Int!
   range: SalaryRange!
 }
 
@@ -319,6 +318,7 @@ type SalaryWorkTimeStatistics {
   has_compensatory_dayoff_count: YesNoOrUnknownCount
   has_overtime_salary_count: YesNoOrUnknownCount
   is_overtime_salary_legal_count: YesNoOrUnknownCount
+  overtime_frequency_count: [OvertimeFrequencyCount!]!
 }
 
 enum SearchBy {

--- a/schema.graphql
+++ b/schema.graphql
@@ -3,18 +3,32 @@ type Archive {
   reason: String!
 }
 
+"""單一公司單一職稱的平均薪資"""
+type AverageSalary {
+  job_title: JobTitle!
+  company: Company!
+  data_num: Int!
+  average_salary: Salary!
+}
+
 type Company {
   name: String!
 
   """取得資料本身"""
   salary_work_times: [SalaryWorkTime!]!
-  work_experiences(start: Int, limit: Int): [WorkExperience]!
-  interview_experiences(start: Int, limit: Int): [InterviewExperience]
+  work_experiences(start: Int, limit: Int): [WorkExperience!]!
+  interview_experiences(start: Int, limit: Int): [InterviewExperience!]!
 
   """取得統計資訊"""
   salary_work_time_statistics: SalaryWorkTimeStatistics!
   work_experience_statistics: WorkExperienceStatistics!
   interview_experience_statistics: InterviewExperienceStatistics!
+}
+
+"""單一公司內不同職稱的平均薪資資料"""
+type companyAverageSalary {
+  company: Company!
+  average_salaries: [AverageSalary!]
 }
 
 scalar Date
@@ -44,13 +58,19 @@ interface Experience {
   education: String
   salary: Salary
   title: String
-  sections: [Section]!
+  sections: [Section!]!
   created_at: Date!
   reply_count: Int!
   report_count: Int!
   like_count: Int!
   status: PublishStatus!
   archive: Archive!
+
+  """使用者是否按贊 (null 代表未傳入驗證資訊)"""
+  liked: Boolean
+
+  """preview，通常是列表時可以用來簡單預覽內容"""
+  preview: String
 }
 
 enum ExperienceType {
@@ -65,6 +85,35 @@ enum Gender {
   other
 }
 
+type InternExperience implements Experience {
+  id: ID!
+  type: ExperienceType!
+  company: Company!
+  job_title: JobTitle!
+  region: String!
+  experience_in_year: Int
+  education: String
+  salary: Salary
+  title: String
+  sections: [Section!]!
+  created_at: Date!
+  reply_count: Int!
+  report_count: Int!
+  like_count: Int!
+  status: PublishStatus!
+  archive: Archive!
+
+  """使用者是否按贊 (null 代表未傳入驗證資訊)"""
+  liked: Boolean
+
+  """preview，通常是列表時可以用來簡單預覽內容"""
+  preview: String
+
+  """intern experience specific fields"""
+  starting_year: Int
+  overall_rating: Float
+}
+
 type InterviewExperience implements Experience {
   id: ID!
   type: ExperienceType!
@@ -75,7 +124,7 @@ type InterviewExperience implements Experience {
   education: String
   salary: Salary
   title: String
-  sections: [Section]!
+  sections: [Section!]!
   created_at: Date!
   reply_count: Int!
   report_count: Int!
@@ -83,12 +132,18 @@ type InterviewExperience implements Experience {
   status: PublishStatus!
   archive: Archive!
 
+  """使用者是否按贊 (null 代表未傳入驗證資訊)"""
+  liked: Boolean
+
+  """preview，通常是列表時可以用來簡單預覽內容"""
+  preview: String
+
   """interview experience specific fields"""
   interview_time: YearMonth!
   interview_result: String!
   overall_rating: Int!
-  interview_qas: [InterviewQuestion]
-  interview_sensitive_questions: [String]
+  interview_qas: [InterviewQuestion!]
+  interview_sensitive_questions: [String!]
 }
 
 type InterviewExperienceStatistics {
@@ -106,8 +161,8 @@ type JobTitle {
 
   """取得資料本身"""
   salary_work_times: [SalaryWorkTime!]!
-  work_experiences(start: Int, limit: Int): [WorkExperience]!
-  interview_experiences(start: Int, limit: Int): [InterviewExperience]
+  work_experiences(start: Int, limit: Int): [WorkExperience!]!
+  interview_experiences(start: Int, limit: Int): [InterviewExperience!]!
 
   """取得統計資訊"""
   salary_work_time_statistics: SalaryWorkTimeStatistics!
@@ -115,8 +170,36 @@ type JobTitle {
   interview_experience_statistics: InterviewExperienceStatistics!
 }
 
+"""單一職稱的薪資分布"""
+type JobTitleSalaryDistribution {
+  job_title: JobTitle!
+  bins: [SalaryDistributionBin!]
+}
+
+type LaborRight {
+  id: ID!
+  title: String!
+  coverUrl: String
+  order: Int
+  description: String!
+  content: String!
+  seoTitle: String
+  seoDescription: String
+  seoText: String
+  nPublicPages: Int
+  descriptionInPermissionBlock: String
+}
+
 type Mutation {
   placeholder: Boolean
+
+  """發送驗證信"""
+  sendVerifyEmail(input: SendVerifyEmailInput!): SendVerifyEmailPayload!
+
+  """驗證信箱"""
+  verifyEmail(input: VerifyEmailInput!): VerifyEmailPayload!
+  viewSalaryWorkTimes(input: ViewSalaryWorkTimesInput!): ViewSalaryWorkTimesPayload!
+  viewExperiences(input: ViewExperiencesInput!): ViewExperiencesPayload!
 }
 
 enum Order {
@@ -132,7 +215,6 @@ enum PublishStatus {
 
 type Query {
   placeholder: Boolean
-  salary_work_time_count: Int!
   work_experience_count: Int!
   interview_experience_count: Int!
   company_keywords(limit: Int = 5): [String!]!
@@ -141,13 +223,29 @@ type Query {
 
   """取得單篇經驗分享"""
   experience(id: ID!): Experience
+  popular_experiences(
+    """返回的資料筆數，須 <= 20"""
+    returnNumber: Int = 3
+    sampleNumber: Int = 20
+  ): [Experience!]!
   job_title_keywords(limit: Int = 5): [String!]!
   search_job_titles(query: String!): [JobTitle!]!
   job_title(name: String!): JobTitle
+  labor_rights: [LaborRight!]!
+  labor_right(id: ID!): LaborRight
   me: User!
 
   """取得薪資工時列表 （未下關鍵字搜尋的情況），只有從最新排到最舊"""
-  salary_work_times: [SalaryWorkTime]!
+  salary_work_times(start: Int!, limit: Int!): [SalaryWorkTime!]!
+
+  """薪資工時總數"""
+  salary_work_time_count: Int!
+
+  """取得資料數較多的公司，不同職業的平均薪資"""
+  popular_company_average_salary: [companyAverageSalary]
+
+  """取得資料數較多的職稱的薪資分佈"""
+  popular_job_title_salary_distribution: [JobTitleSalaryDistribution]
 }
 
 type Reply {
@@ -169,6 +267,18 @@ type Reply {
 type Salary {
   type: SalaryType
   amount: Int
+}
+
+"""薪資分布的一個 bin（範圍＋數量）"""
+type SalaryDistributionBin {
+  data_num: Int!
+  range: SalaryRange!
+}
+
+type SalaryRange {
+  type: SalaryType!
+  from: Int!
+  to: Int!
 }
 
 enum SalaryType {
@@ -193,12 +303,13 @@ type SalaryWorkTime {
   created_at: Date!
   data_time: YearMonth!
   estimated_hourly_wage: Float
+  about_this_job: String
 }
 
 type SalaryWorkTimeStatistics {
   count: Int!
-  average_week_work_time: Float!
-  average_estimated_hourly_wage: Float!
+  average_week_work_time: Float
+  average_estimated_hourly_wage: Float
   has_compensatory_dayoff_count: YesNoOrUnknownCount
   has_overtime_salary_count: YesNoOrUnknownCount
   is_overtime_salary_legal_count: YesNoOrUnknownCount
@@ -212,6 +323,18 @@ enum SearchBy {
 type Section {
   subtitle: String
   content: String
+}
+
+input SendVerifyEmailInput {
+  """要驗證的使用者的信箱"""
+  email: String!
+
+  """驗證成功後，按鈕會導向的 URL"""
+  redirect_url: String!
+}
+
+type SendVerifyEmailPayload {
+  status: String!
 }
 
 enum SortBy {
@@ -241,6 +364,36 @@ type User {
   salary_work_time_count: Int!
 }
 
+input VerifyEmailInput {
+  token: String!
+}
+
+type VerifyEmailPayload {
+  """登入用 token"""
+  token: String!
+
+  """驗證成功後，按鈕會導向的 URL，與 SendVerifyEmailInput 一致"""
+  redirect_url: String!
+}
+
+input ViewExperiencesInput {
+  content_ids: [String!]!
+  referrer: String
+}
+
+type ViewExperiencesPayload {
+  status: String!
+}
+
+input ViewSalaryWorkTimesInput {
+  content_ids: [String!]!
+  referrer: String
+}
+
+type ViewSalaryWorkTimesPayload {
+  status: String!
+}
+
 type WorkExperience implements Experience {
   id: ID!
   type: ExperienceType!
@@ -251,7 +404,7 @@ type WorkExperience implements Experience {
   education: String
   salary: Salary
   title: String
-  sections: [Section]!
+  sections: [Section!]!
   created_at: Date!
   reply_count: Int!
   report_count: Int!
@@ -259,9 +412,15 @@ type WorkExperience implements Experience {
   status: PublishStatus!
   archive: Archive!
 
+  """使用者是否按贊 (null 代表未傳入驗證資訊)"""
+  liked: Boolean
+
+  """preview，通常是列表時可以用來簡單預覽內容"""
+  preview: String
+
   """work experience specific fields"""
   data_time: YearMonth
-  week_work_time: Int
+  week_work_time: Float
   recommend_to_others: String
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -23,6 +23,9 @@ type Company {
   salary_work_time_statistics: SalaryWorkTimeStatistics!
   work_experience_statistics: WorkExperienceStatistics!
   interview_experience_statistics: InterviewExperienceStatistics!
+
+  """該公司內不同職業的平均薪資"""
+  job_title_average_salaries: [AverageSalary!]
 }
 
 """單一公司內不同職稱的平均薪資資料"""
@@ -168,6 +171,9 @@ type JobTitle {
   salary_work_time_statistics: SalaryWorkTimeStatistics!
   work_experience_statistics: WorkExperienceStatistics!
   interview_experience_statistics: InterviewExperienceStatistics!
+
+  """該職業的薪資分布"""
+  salary_distribution: JobTitleSalaryDistribution!
 }
 
 """單一職稱的薪資分布"""

--- a/src/schema/company.js
+++ b/src/schema/company.js
@@ -24,7 +24,9 @@ const Query = gql`
     extend type Query {
         search_companies(query: String!): [Company!]!
         company(name: String!): Company
-        popular_companies: [Company!]!
+
+        "目前用途：取得薪資資料前 topN 多的公司，且至少有三種職稱各至少有三筆資料"
+        popular_companies(limit: Int = 5): [Company!]!
     }
 `;
 

--- a/src/schema/company.js
+++ b/src/schema/company.js
@@ -16,7 +16,7 @@ const Type = gql`
         interview_experience_statistics: InterviewExperienceStatistics!
 
         "該公司內不同職業的平均薪資"
-        job_title_average_salaries: [AverageSalary!]
+        average_salaries: [AverageSalary!]
     }
 `;
 
@@ -24,6 +24,7 @@ const Query = gql`
     extend type Query {
         search_companies(query: String!): [Company!]!
         company(name: String!): Company
+        popular_companies: [Company!]!
     }
 `;
 
@@ -90,6 +91,11 @@ const resolvers = {
                 return null;
             }
         },
+        popular_companies: async () => [
+            {
+                name: "聯發科",
+            },
+        ],
     },
     Company: {
         salary_work_times: async (company, _, { manager }) => {
@@ -115,43 +121,43 @@ const resolvers = {
         work_experience_statistics: () => {},
         interview_experience_statistics: () => {},
 
-        job_title_average_salaries: () => {
+        average_salaries: () => {
             return [
                 {
-                    job_title: {
-                        name: "軟體工程師",
-                    },
                     company: {
                         name: "聯發科",
                     },
-                    data_num: 5,
-                    average_salary: {
+                    job_title: {
+                        name: "軟體工程師",
+                    },
+                    data_count: 5,
+                    salary: {
                         amount: 76000,
                         type: "month",
                     },
                 },
                 {
-                    job_title: {
-                        name: "數位IC設計工程師",
-                    },
                     company: {
                         name: "聯發科",
                     },
-                    data_num: 10,
-                    average_salary: {
+                    job_title: {
+                        name: "數位IC設計工程師",
+                    },
+                    data_count: 10,
+                    salary: {
                         amount: 100000,
                         type: "month",
                     },
                 },
                 {
-                    job_title: {
-                        name: "硬體工程師",
-                    },
                     company: {
                         name: "聯發科",
                     },
-                    data_num: 10,
-                    average_salary: {
+                    job_title: {
+                        name: "硬體工程師",
+                    },
+                    data_count: 10,
+                    salary: {
                         amount: 80000,
                         type: "month",
                     },

--- a/src/schema/company.js
+++ b/src/schema/company.js
@@ -14,6 +14,9 @@ const Type = gql`
         salary_work_time_statistics: SalaryWorkTimeStatistics!
         work_experience_statistics: WorkExperienceStatistics!
         interview_experience_statistics: InterviewExperienceStatistics!
+
+        "該公司內不同職業的平均薪資"
+        job_title_average_salaries: [AverageSalary!]
     }
 `;
 
@@ -111,6 +114,50 @@ const resolvers = {
         },
         work_experience_statistics: () => {},
         interview_experience_statistics: () => {},
+
+        job_title_average_salaries: () => {
+            return [
+                {
+                    job_title: {
+                        name: "軟體工程師",
+                    },
+                    company: {
+                        name: "聯發科",
+                    },
+                    data_num: 5,
+                    average_salary: {
+                        amount: 76000,
+                        type: "month",
+                    },
+                },
+                {
+                    job_title: {
+                        name: "數位IC設計工程師",
+                    },
+                    company: {
+                        name: "聯發科",
+                    },
+                    data_num: 10,
+                    average_salary: {
+                        amount: 100000,
+                        type: "month",
+                    },
+                },
+                {
+                    job_title: {
+                        name: "硬體工程師",
+                    },
+                    company: {
+                        name: "聯發科",
+                    },
+                    data_num: 10,
+                    average_salary: {
+                        amount: 80000,
+                        type: "month",
+                    },
+                },
+            ];
+        },
     },
 };
 

--- a/src/schema/job_title.js
+++ b/src/schema/job_title.js
@@ -16,7 +16,7 @@ const Type = gql`
         interview_experience_statistics: InterviewExperienceStatistics!
 
         "該職業的薪資分布"
-        salary_distribution: JobTitleSalaryDistribution!
+        salary_distribution: SalaryDistribution!
     }
 `;
 
@@ -24,6 +24,7 @@ const Query = gql`
     extend type Query {
         search_job_titles(query: String!): [JobTitle!]!
         job_title(name: String!): JobTitle
+        popular_job_titles: [JobTitle!]!
     }
 `;
 
@@ -65,6 +66,11 @@ const resolvers = {
                 name: result.job_title,
             };
         },
+        popular_job_titles: async () => [
+            {
+                name: "軟體工程師",
+            },
+        ],
     },
     JobTitle: {
         salary_work_times: async (jobTitle, _, { manager }) => {
@@ -93,12 +99,9 @@ const resolvers = {
 
         salary_distribution: () => {
             return {
-                job_title: {
-                    name: "軟體工程師",
-                },
                 bins: [
                     {
-                        data_num: 5,
+                        data_count: 5,
                         range: {
                             type: "month",
                             from: 30000,
@@ -106,7 +109,7 @@ const resolvers = {
                         },
                     },
                     {
-                        data_num: 10,
+                        data_count: 10,
                         range: {
                             type: "month",
                             from: 40000,
@@ -114,7 +117,7 @@ const resolvers = {
                         },
                     },
                     {
-                        data_num: 20,
+                        data_count: 20,
                         range: {
                             type: "month",
                             from: 50000,
@@ -122,7 +125,7 @@ const resolvers = {
                         },
                     },
                     {
-                        data_num: 10,
+                        data_count: 10,
                         range: {
                             type: "month",
                             from: 60000,

--- a/src/schema/job_title.js
+++ b/src/schema/job_title.js
@@ -24,7 +24,9 @@ const Query = gql`
     extend type Query {
         search_job_titles(query: String!): [JobTitle!]!
         job_title(name: String!): JobTitle
-        popular_job_titles: [JobTitle!]!
+
+        "目前用途：取得薪資資料前 topN 多的職稱"
+        popular_job_titles(limit: Int = 5): [JobTitle!]!
     }
 `;
 

--- a/src/schema/job_title.js
+++ b/src/schema/job_title.js
@@ -14,6 +14,9 @@ const Type = gql`
         salary_work_time_statistics: SalaryWorkTimeStatistics!
         work_experience_statistics: WorkExperienceStatistics!
         interview_experience_statistics: InterviewExperienceStatistics!
+
+        "該職業的薪資分布"
+        salary_distribution: JobTitleSalaryDistribution!
     }
 `;
 
@@ -87,6 +90,48 @@ const resolvers = {
         // TODO
         work_experience_statistics: () => {},
         interview_experience_statistics: () => {},
+
+        salary_distribution: () => {
+            return {
+                job_title: {
+                    name: "軟體工程師",
+                },
+                bins: [
+                    {
+                        data_num: 5,
+                        range: {
+                            type: "month",
+                            from: 30000,
+                            to: 40000,
+                        },
+                    },
+                    {
+                        data_num: 10,
+                        range: {
+                            type: "month",
+                            from: 40000,
+                            to: 50000,
+                        },
+                    },
+                    {
+                        data_num: 20,
+                        range: {
+                            type: "month",
+                            from: 50000,
+                            to: 60000,
+                        },
+                    },
+                    {
+                        data_num: 10,
+                        range: {
+                            type: "month",
+                            from: 60000,
+                            to: 70000,
+                        },
+                    },
+                ],
+            };
+        },
     },
 };
 

--- a/src/schema/salary_work_time.js
+++ b/src/schema/salary_work_time.js
@@ -32,6 +32,13 @@ const Type = gql`
         has_compensatory_dayoff_count: YesNoOrUnknownCount
         has_overtime_salary_count: YesNoOrUnknownCount
         is_overtime_salary_legal_count: YesNoOrUnknownCount
+        overtime_frequency_count: [OvertimeFrequencyCount!]!
+    }
+
+    "加班頻率的次數"
+    type OvertimeFrequencyCount {
+        overtime_frequency: Int!
+        count: Int!
     }
 
     "單一公司單一職稱的平均薪資"
@@ -220,6 +227,27 @@ const resolvers = {
                 no: counts["no"] || 0,
                 unknown: counts["don't know"] || 0,
             };
+        },
+        // TODO
+        overtime_frequency_count: () => {
+            return [
+                {
+                    overtime_frequency: 0,
+                    count: 5,
+                },
+                {
+                    overtime_frequency: 1,
+                    count: 10,
+                },
+                {
+                    overtime_frequency: 2,
+                    count: 20,
+                },
+                {
+                    overtime_frequency: 0,
+                    count: 30,
+                },
+            ];
         },
     },
     Query: {

--- a/src/schema/salary_work_time.js
+++ b/src/schema/salary_work_time.js
@@ -34,6 +34,38 @@ const Type = gql`
         is_overtime_salary_legal_count: YesNoOrUnknownCount
     }
 
+    "單一公司內不同職稱的平均薪資資料"
+    type companyAverageSalary {
+        company: Company!
+        average_salaries: [AverageSalary!]
+    }
+
+    "單一公司單一職稱的平均薪資"
+    type AverageSalary {
+        job_title: JobTitle!
+        company: Company!
+        data_num: Int!
+        average_salary: Salary!
+    }
+
+    "單一職稱的薪資分布"
+    type JobTitleSalaryDistribution {
+        job_title: JobTitle!
+        bins: [SalaryDistributionBin!]
+    }
+
+    "薪資分布的一個 bin（範圍＋數量）"
+    type SalaryDistributionBin {
+        data_num: Int!
+        range: SalaryRange!
+    }
+
+    type SalaryRange {
+        type: SalaryType!
+        from: Int!
+        to: Int!
+    }
+
     type YearMonth {
         year: Int!
         month: Int!
@@ -102,6 +134,12 @@ const Query = gql`
 
         "薪資工時總數"
         salary_work_time_count: Int!
+
+        "取得資料數較多的公司，不同職業的平均薪資"
+        popular_company_average_salary: [companyAverageSalary]
+
+        "取得資料數較多的職稱的薪資分佈"
+        popular_job_title_salary_distribution: [JobTitleSalaryDistribution]
     }
 `;
 
@@ -236,6 +274,178 @@ const resolvers = {
                 query
             );
             return count;
+        },
+        // TODO
+        popular_company_average_salary() {
+            return [
+                {
+                    company: {
+                        name: "聯發科",
+                    },
+                    average_salaries: [
+                        {
+                            job_title: {
+                                name: "軟體工程師",
+                            },
+                            company: {
+                                name: "聯發科",
+                            },
+                            data_num: 5,
+                            average_salary: {
+                                amount: 76000,
+                                type: "month",
+                            },
+                        },
+                        {
+                            job_title: {
+                                name: "數位IC設計工程師",
+                            },
+                            company: {
+                                name: "聯發科",
+                            },
+                            data_num: 10,
+                            average_salary: {
+                                amount: 100000,
+                                type: "month",
+                            },
+                        },
+                        {
+                            job_title: {
+                                name: "硬體工程師",
+                            },
+                            company: {
+                                name: "聯發科",
+                            },
+                            data_num: 10,
+                            average_salary: {
+                                amount: 80000,
+                                type: "month",
+                            },
+                        },
+                    ],
+                },
+                {
+                    company: {
+                        name: "大立光",
+                    },
+                    average_salaries: [
+                        {
+                            job_title: {
+                                name: "製程工程師",
+                            },
+                            company: {
+                                name: "大立光",
+                            },
+                            data_num: 5,
+                            average_salary: {
+                                amount: 76000,
+                                type: "month",
+                            },
+                        },
+                        {
+                            job_title: {
+                                name: "數位IC設計工程師",
+                            },
+                            company: {
+                                name: "大立光",
+                            },
+                            data_num: 10,
+                            average_salary: {
+                                amount: 100000,
+                                type: "month",
+                            },
+                        },
+                        {
+                            job_title: {
+                                name: "硬體工程師",
+                            },
+                            company: {
+                                name: "大立光",
+                            },
+                            data_num: 10,
+                            average_salary: {
+                                amount: 80000,
+                                type: "month",
+                            },
+                        },
+                    ],
+                },
+            ];
+        },
+        // TODO
+        popular_job_title_salary_distribution() {
+            return [
+                {
+                    job_title: {
+                        name: "軟體工程師",
+                    },
+                    bins: [
+                        {
+                            data_num: 5,
+                            range: {
+                                type: "month",
+                                from: 30000,
+                                to: 40000,
+                            },
+                        },
+                        {
+                            data_num: 10,
+                            range: {
+                                type: "month",
+                                from: 40000,
+                                to: 50000,
+                            },
+                        },
+                        {
+                            data_num: 20,
+                            range: {
+                                type: "month",
+                                from: 50000,
+                                to: 60000,
+                            },
+                        },
+                        {
+                            data_num: 10,
+                            range: {
+                                type: "month",
+                                from: 60000,
+                                to: 70000,
+                            },
+                        },
+                    ],
+                },
+                {
+                    job_title: {
+                        name: "設計師",
+                    },
+                    bins: [
+                        {
+                            data_num: 10,
+                            range: {
+                                type: "month",
+                                from: 30000,
+                                to: 40000,
+                            },
+                        },
+                        {
+                            data_num: 20,
+                            range: {
+                                type: "month",
+                                from: 40000,
+                                to: 50000,
+                            },
+                        },
+                        {
+                            data_num: 5,
+                            range: {
+                                type: "month",
+                                from: 50000,
+                                to: 60000,
+                            },
+                        },
+                    ],
+                },
+            ];
         },
     },
 };

--- a/src/schema/salary_work_time.js
+++ b/src/schema/salary_work_time.js
@@ -34,29 +34,22 @@ const Type = gql`
         is_overtime_salary_legal_count: YesNoOrUnknownCount
     }
 
-    "單一公司內不同職稱的平均薪資資料"
-    type companyAverageSalary {
-        company: Company!
-        average_salaries: [AverageSalary!]
-    }
-
     "單一公司單一職稱的平均薪資"
     type AverageSalary {
-        job_title: JobTitle!
         company: Company!
-        data_num: Int!
-        average_salary: Salary!
+        job_title: JobTitle!
+        data_count: Int!
+        salary: Salary!
     }
 
-    "單一職稱的薪資分布"
-    type JobTitleSalaryDistribution {
-        job_title: JobTitle!
+    "薪資分布"
+    type SalaryDistribution {
         bins: [SalaryDistributionBin!]
     }
 
     "薪資分布的一個 bin（範圍＋數量）"
     type SalaryDistributionBin {
-        data_num: Int!
+        data_count: Int!
         range: SalaryRange!
     }
 
@@ -134,12 +127,6 @@ const Query = gql`
 
         "薪資工時總數"
         salary_work_time_count: Int!
-
-        "取得資料數較多的公司，不同職業的平均薪資"
-        popular_company_average_salary: [companyAverageSalary]
-
-        "取得資料數較多的職稱的薪資分佈"
-        popular_job_title_salary_distribution: [JobTitleSalaryDistribution]
     }
 `;
 
@@ -274,178 +261,6 @@ const resolvers = {
                 query
             );
             return count;
-        },
-        // TODO
-        popular_company_average_salary() {
-            return [
-                {
-                    company: {
-                        name: "聯發科",
-                    },
-                    average_salaries: [
-                        {
-                            job_title: {
-                                name: "軟體工程師",
-                            },
-                            company: {
-                                name: "聯發科",
-                            },
-                            data_num: 5,
-                            average_salary: {
-                                amount: 76000,
-                                type: "month",
-                            },
-                        },
-                        {
-                            job_title: {
-                                name: "數位IC設計工程師",
-                            },
-                            company: {
-                                name: "聯發科",
-                            },
-                            data_num: 10,
-                            average_salary: {
-                                amount: 100000,
-                                type: "month",
-                            },
-                        },
-                        {
-                            job_title: {
-                                name: "硬體工程師",
-                            },
-                            company: {
-                                name: "聯發科",
-                            },
-                            data_num: 10,
-                            average_salary: {
-                                amount: 80000,
-                                type: "month",
-                            },
-                        },
-                    ],
-                },
-                {
-                    company: {
-                        name: "大立光",
-                    },
-                    average_salaries: [
-                        {
-                            job_title: {
-                                name: "製程工程師",
-                            },
-                            company: {
-                                name: "大立光",
-                            },
-                            data_num: 5,
-                            average_salary: {
-                                amount: 76000,
-                                type: "month",
-                            },
-                        },
-                        {
-                            job_title: {
-                                name: "數位IC設計工程師",
-                            },
-                            company: {
-                                name: "大立光",
-                            },
-                            data_num: 10,
-                            average_salary: {
-                                amount: 100000,
-                                type: "month",
-                            },
-                        },
-                        {
-                            job_title: {
-                                name: "硬體工程師",
-                            },
-                            company: {
-                                name: "大立光",
-                            },
-                            data_num: 10,
-                            average_salary: {
-                                amount: 80000,
-                                type: "month",
-                            },
-                        },
-                    ],
-                },
-            ];
-        },
-        // TODO
-        popular_job_title_salary_distribution() {
-            return [
-                {
-                    job_title: {
-                        name: "軟體工程師",
-                    },
-                    bins: [
-                        {
-                            data_num: 5,
-                            range: {
-                                type: "month",
-                                from: 30000,
-                                to: 40000,
-                            },
-                        },
-                        {
-                            data_num: 10,
-                            range: {
-                                type: "month",
-                                from: 40000,
-                                to: 50000,
-                            },
-                        },
-                        {
-                            data_num: 20,
-                            range: {
-                                type: "month",
-                                from: 50000,
-                                to: 60000,
-                            },
-                        },
-                        {
-                            data_num: 10,
-                            range: {
-                                type: "month",
-                                from: 60000,
-                                to: 70000,
-                            },
-                        },
-                    ],
-                },
-                {
-                    job_title: {
-                        name: "設計師",
-                    },
-                    bins: [
-                        {
-                            data_num: 10,
-                            range: {
-                                type: "month",
-                                from: 30000,
-                                to: 40000,
-                            },
-                        },
-                        {
-                            data_num: 20,
-                            range: {
-                                type: "month",
-                                from: 40000,
-                                to: 50000,
-                            },
-                        },
-                        {
-                            data_num: 5,
-                            range: {
-                                type: "month",
-                                from: 50000,
-                                to: 60000,
-                            },
-                        },
-                    ],
-                },
-            ];
         },
     },
 };


### PR DESCRIPTION
- [x] 下 資料前 N 多的公司，不同職業的平均薪資 query ，應該要正常回傳假資料（for 首頁）
**performance應該蠻差的，要進Redis**
```
query {
  popular_companies {
    name
    average_salaries {
      job_title {
        name
      }
      data_count
      salary {
        amount
        type
      }
    }
  }
}
```
- [ ]  下 資料前 N 多的職業的薪資分布 的 query ，應該要能正常回傳假資料（for 首頁)
```
query {
  popular_job_titles {
    name,
    salary_distribution {
      bins {
        data_count
        range {
          from
          to
          type
        }
      }
    }
  }
}
```
- [ ]  下 單一公司不同職業的薪資分布 的 query ，應該要能正常回傳假資料 （for 公司頁）
```
query {
  company (name: "聯發科") {
    name
    average_salaries {
      job_title {
        name
      }
      data_count
      salary {
        amount
        type
      }
    }
  }
}

```
- [ ]  下 單一職業薪資分布 的 query ，應該要能正常回傳假資料 （for 職稱頁）
```
query {
  job_title(name: "軟體工程師") {
    salary_distribution {
      bins {
        data_count
        range {
          from
          to
          type
        }
      }
    }
  }
}
```

### 1 ![image](https://user-images.githubusercontent.com/13104102/67942243-65db6a00-fc12-11e9-9115-d1a7d6a50a68.png)
